### PR TITLE
Refactor artisan commands to use Laravel collection and helper methods

### DIFF
--- a/src/Commands/SkeemaBaseCommand.php
+++ b/src/Commands/SkeemaBaseCommand.php
@@ -80,7 +80,6 @@ abstract class SkeemaBaseCommand extends Command
         return 0;
     }
 
-
     /**
      * Get the path to the skeema configuration file.
      *
@@ -105,7 +104,7 @@ abstract class SkeemaBaseCommand extends Command
             ->replaceFirst('skeema.', '')
             ->toString();
 
-        if (filled($optionKey) &&  $this->hasOption($optionKey)) {
+        if (filled($optionKey) && $this->hasOption($optionKey)) {
             return $this->option($optionKey);
         }
 
@@ -295,14 +294,14 @@ abstract class SkeemaBaseCommand extends Command
      */
     protected function getSkeemaCommand(string $command, array $arguments = [], bool $withBaseArgs = true): string
     {
-       return Str::of($this->getConfig('skeema.bin', 'skeema'))
-            ->append(' '.$command)
-            ->append(' '.$this->serializeArgs($arguments))
-            ->when(
-                filled($withBaseArgs),
-                fn ($command) => $command->append(' '.$this->serializeArgs($this->getBaseArgs()))
-            )
-            ->toString();
+        return Str::of($this->getConfig('skeema.bin', 'skeema'))
+             ->append(' '.$command)
+             ->append(' '.$this->serializeArgs($arguments))
+             ->when(
+                 filled($withBaseArgs),
+                 fn ($command) => $command->append(' '.$this->serializeArgs($this->getBaseArgs()))
+             )
+             ->toString();
     }
 
     /**

--- a/src/Commands/SkeemaBaseCommand.php
+++ b/src/Commands/SkeemaBaseCommand.php
@@ -298,8 +298,8 @@ abstract class SkeemaBaseCommand extends Command
              ->append(' '.$command)
              ->append(' '.$this->serializeArgs($arguments))
              ->when(
-                 filled($withBaseArgs),
-                 fn ($command) => $command->append(' '.$this->serializeArgs($this->getBaseArgs()))
+                 $withBaseArgs,
+                 fn ($skeemaCommand) => $skeemaCommand->append(' '.$this->serializeArgs($this->getBaseArgs()))
              )
              ->toString();
     }
@@ -314,9 +314,9 @@ abstract class SkeemaBaseCommand extends Command
         }
 
         if ($this->applicationIsRunningInProduction()) {
-            $this->warn($warning);
+            $this->warn('Attention - Your consent has significant implications.');
 
-            if ($this->confirm('Do you really want to proceed?', false)) {
+            if ($this->confirm($warning.' Proceed?', false)) {
                 return;
             }
 

--- a/src/Commands/SkeemaBaseCommand.php
+++ b/src/Commands/SkeemaBaseCommand.php
@@ -51,8 +51,6 @@ abstract class SkeemaBaseCommand extends Command
      */
     public function handle(): int
     {
-        $exitCode = 0;
-
         $this->files = $this->laravel->get(Filesystem::class);
 
         $this->processFactory = function (...$arguments) {
@@ -68,27 +66,27 @@ abstract class SkeemaBaseCommand extends Command
 
             $this->runProcess($command);
         } catch (\Smakecloud\Skeema\Exceptions\ExceptionWithExitCode $e) {
-            $this->error($e->getMessage());
+            collect([$e->getMessage()])
+                ->each(fn ($message) => $this->error($message));
 
-            $exitCode = $e->getExitCode();
+            return $e->getExitCode();
+        } catch (\Exception $e) {
+            collect([$e->getMessage()])
+                ->each(fn ($message) => $this->error($message));
+
+            return -1;
         }
-        // @codeCoverageIgnoreStart
-        catch (\Exception $e) {
-            $this->error($e->getMessage());
 
-            $exitCode = -1;
-        }
-        // @codeCoverageIgnoreEnd
-
-        return $exitCode;
+        return 0;
     }
+
 
     /**
      * Get the path to the skeema configuration file.
      *
      * @return string
      */
-    protected function getSkeemaDir()
+    protected function getSkeemaDir(): string
     {
         return $this->laravel->basePath(
             $this->getConfig('skeema.dir', 'database'.DIRECTORY_SEPARATOR.'skeema')
@@ -102,14 +100,13 @@ abstract class SkeemaBaseCommand extends Command
      */
     protected function getConfig(string $key, mixed $default = null)
     {
-        if (Str::startsWith($key, 'skeema.')) {
-            $replacedString = Str::of($key)
-                ->replaceFirst('skeema.', '')
-                ->toString();
+        $optionKey = Str::of($key)
+            ->prepend('skeema.')
+            ->replaceFirst('skeema.', '')
+            ->toString();
 
-            if ($this->hasOption($replacedString)) {
-                return $this->option($replacedString);
-            }
+        if (filled($optionKey) &&  $this->hasOption($optionKey)) {
+            return $this->option($optionKey);
         }
 
         return $this->laravel->get('config')->get($key, $default);
@@ -154,7 +151,7 @@ abstract class SkeemaBaseCommand extends Command
      *
      * @return void
      */
-    protected function ensureSkeemaDirExists()
+    protected function ensureSkeemaDirExists(): void
     {
         if (! $this->files->exists($this->getSkeemaDir())) {
             $this->files->makeDirectory($this->getSkeemaDir(), 0755, true);
@@ -167,7 +164,7 @@ abstract class SkeemaBaseCommand extends Command
      * @param  string  $command
      * @return void
      */
-    protected function runProcess($command)
+    protected function runProcess($command): void
     {
         $process = call_user_func(
             $this->processFactory,
@@ -210,7 +207,7 @@ abstract class SkeemaBaseCommand extends Command
      * @param  string  $buffer
      * @return void
      */
-    protected function onOutput($type, $buffer)
+    protected function onOutput($type, $buffer): void
     {
         $re = '/^(\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d) \[([A-Z]*)\] (.*)$/m';
         preg_match_all($re, $buffer, $matches, PREG_SET_ORDER, 0);
@@ -298,15 +295,14 @@ abstract class SkeemaBaseCommand extends Command
      */
     protected function getSkeemaCommand(string $command, array $arguments = [], bool $withBaseArgs = true): string
     {
-        $command = Str::of($this->getConfig('skeema.bin', 'skeema'))
+       return Str::of($this->getConfig('skeema.bin', 'skeema'))
             ->append(' '.$command)
-            ->append(' '.$this->serializeArgs($arguments));
-
-        if ($withBaseArgs) {
-            $command = $command->append(' '.$this->serializeArgs($this->getBaseArgs()));
-        }
-
-        return $command->toString();
+            ->append(' '.$this->serializeArgs($arguments))
+            ->when(
+                filled($withBaseArgs),
+                fn ($command) => $command->append(' '.$this->serializeArgs($this->getBaseArgs()))
+            )
+            ->toString();
     }
 
     /**
@@ -319,7 +315,9 @@ abstract class SkeemaBaseCommand extends Command
         }
 
         if ($this->applicationIsRunningInProduction()) {
-            if ($this->confirm($warning.' Proceed?', false)) {
+            $this->warn($warning);
+
+            if ($this->confirm('Do you really want to proceed?', false)) {
                 return;
             }
 

--- a/src/Commands/SkeemaDiffCommand.php
+++ b/src/Commands/SkeemaDiffCommand.php
@@ -78,26 +78,27 @@ class SkeemaDiffCommand extends SkeemaBaseCommand
     {
         $args = collect([
             'temp-schema' => $this->option('temp-schema') ?? $this->getTempSchemaName(),
-            'temp-schema-threads' => ($this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads'))) ? $this->option('temp-schema-threads') : null,
+            'temp-schema-threads' => $this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads')) ? $this->option('temp-schema-threads') : null,
             'temp-schema-binlog' => $this->option('temp-schema-binlog'),
             'alter-algorithm' => $this->option('alter-algorithm'),
             'alter-lock' => $this->option('alter-lock'),
-            'alter-validate-virtual' => $this->option('alter-validate-virtual'),
-            'compare-metadata' => $this->option('compare-metadata'),
-            'exact-match' => $this->option('exact-match'),
-            'allow-unsafe' => $this->option('allow-unsafe'),
-            'skip-verify' => $this->option('skip-verify'),
+            'alter-validate-virtual' => $this->option('alter-validate-virtual') ? true : null,
+            'compare-metadata' => $this->option('compare-metadata') ? true : null,
+            'exact-match' => $this->option('exact-match') ? true : null,
+            'allow-unsafe' => $this->option('allow-unsafe') ? true : null,
+            'skip-verify' => $this->option('skip-verify') ? true : null,
             'partitioning' => $this->option('partitioning'),
-            'strip-definer' => $this->option('strip-definer'),
-            'allow-auto-inc' => $this->option('allow-auto-inc'),
-            'allow-charset' => $this->option('allow-charset'),
-            'allow-compression' => $this->option('allow-compression'),
-            'allow-definer' => $this->option('allow-definer'),
-            'allow-engine' => $this->option('allow-engine'),
+            'strip-definer' => $this->option('strip-definer') ? true : null,
+            'allow-auto-inc' => $this->option('allow-auto-inc') ? true : null,
+            'allow-charset' => $this->option('allow-charset') ? true : null,
+            'allow-compression' => $this->option('allow-compression') ? true : null,
+            'allow-definer' => $this->option('allow-definer') ? true : null,
+            'allow-engine' => $this->option('allow-engine') ? true : null,
             'safe-below-size' => $this->option('safe-below-size'),
         ])
         ->filter()
         ->merge($this->getLintArgs())
+        ->filter()
         ->toArray();
 
         if ($this->getConfig('skeema.alter_wrapper.enabled', false)) {

--- a/src/Commands/SkeemaDiffCommand.php
+++ b/src/Commands/SkeemaDiffCommand.php
@@ -88,12 +88,12 @@ class SkeemaDiffCommand extends SkeemaBaseCommand
             'allow-unsafe' => $this->option('allow-unsafe') ? true : null,
             'skip-verify' => $this->option('skip-verify') ? true : null,
             'partitioning' => $this->option('partitioning'),
-            'strip-definer' => $this->option('strip-definer') ? true : null,
-            'allow-auto-inc' => $this->option('allow-auto-inc') ? true : null,
-            'allow-charset' => $this->option('allow-charset') ? true : null,
-            'allow-compression' => $this->option('allow-compression') ? true : null,
-            'allow-definer' => $this->option('allow-definer') ? true : null,
-            'allow-engine' => $this->option('allow-engine') ? true : null,
+            'strip-definer' => $this->option('strip-definer'),
+            'allow-auto-inc' => $this->option('allow-auto-inc'),
+            'allow-charset' => $this->option('allow-charset'),
+            'allow-compression' => $this->option('allow-compression'),
+            'allow-definer' => $this->option('allow-definer'),
+            'allow-engine' => $this->option('allow-engine'),
             'safe-below-size' => $this->option('safe-below-size'),
         ])
         ->filter()
@@ -121,7 +121,7 @@ class SkeemaDiffCommand extends SkeemaBaseCommand
      *
      * The method merges the base and diff rules, creates an array of options from them.
      *
-     * @return array The associative array of options to run Skeema's lint command with.
+     * @return array<string, mixed> The associative array of options to run Skeema's lint command with.
      */
     private function getLintArgs(): array
     {

--- a/src/Commands/SkeemaDiffCommand.php
+++ b/src/Commands/SkeemaDiffCommand.php
@@ -50,10 +50,10 @@ class SkeemaDiffCommand extends SkeemaBaseCommand
     {
         if ($process->getExitCode() >= 2) {
             throw new \Smakecloud\Skeema\Exceptions\SkeemaDiffExitedWithErrorsException();
-        } else {
-            if (! $this->option('ignore-warnings')) {
-                throw new \Smakecloud\Skeema\Exceptions\SkeemaDiffExitedWithWarningsException();
-            }
+        }
+
+        if (! $this->option('ignore-warnings')) {
+            throw new \Smakecloud\Skeema\Exceptions\SkeemaDiffExitedWithWarningsException();
         }
     }
 
@@ -76,104 +76,65 @@ class SkeemaDiffCommand extends SkeemaBaseCommand
      */
     private function makeArgs(): array
     {
-        $args = [];
-
-        if ($this->option('temp-schema')) {
-            $args['temp-schema'] = $this->option('temp-schema');
-        } else {
-            $args['temp-schema'] = $this->getTempSchemaName();
-        }
-
-        if ($this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads'))) {
-            $args['temp-schema-threads'] = $this->option('temp-schema-threads');
-        }
-
-        if ($this->option('temp-schema-binlog')) {
-            $args['temp-schema-binlog'] = $this->option('temp-schema-binlog');
-        }
-
-        if ($this->option('alter-algorithm')) {
-            $args['alter-algorithm'] = $this->option('alter-algorithm');
-        }
-
-        if ($this->option('alter-lock')) {
-            $args['alter-lock'] = $this->option('alter-lock');
-        }
-
-        if ($this->option('alter-validate-virtual')) {
-            $args['alter-validate-virtual'] = true;
-        }
-
-        if ($this->option('compare-metadata')) {
-            $args['compare-metadata'] = true;
-        }
-
-        if ($this->option('exact-match')) {
-            $args['exact-match'] = true;
-        }
-
-        if ($this->option('allow-unsafe')) {
-            $args['allow-unsafe'] = true;
-        }
-
-        if ($this->option('skip-verify')) {
-            $args['skip-verify'] = true;
-        }
-
-        if ($this->option('partitioning')) {
-            $args['partitioning'] = $this->option('partitioning');
-        }
-
-        if ($this->option('strip-definer')) {
-            $args['strip-definer'] = $this->option('strip-definer');
-        }
-
-        if ($this->option('allow-auto-inc')) {
-            $args['allow-auto-inc'] = $this->option('allow-auto-inc');
-        }
-
-        if ($this->option('allow-charset')) {
-            $args['allow-charset'] = $this->option('allow-charset');
-        }
-
-        if ($this->option('allow-compression')) {
-            $args['allow-compression'] = $this->option('allow-compression');
-        }
-
-        if ($this->option('allow-definer')) {
-            $args['allow-definer'] = $this->option('allow-definer');
-        }
-
-        if ($this->option('allow-engine')) {
-            $args['allow-engine'] = $this->option('allow-engine');
-        }
-
-        if ($this->option('safe-below-size')) {
-            $args['safe-below-size'] = $this->option('safe-below-size');
-        }
+        $args = collect([
+            'temp-schema' => $this->option('temp-schema') ?? $this->getTempSchemaName(),
+            'temp-schema-threads' => ($this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads'))) ? $this->option('temp-schema-threads') : null,
+            'temp-schema-binlog' => $this->option('temp-schema-binlog'),
+            'alter-algorithm' => $this->option('alter-algorithm'),
+            'alter-lock' => $this->option('alter-lock'),
+            'alter-validate-virtual' => $this->option('alter-validate-virtual'),
+            'compare-metadata' => $this->option('compare-metadata'),
+            'exact-match' => $this->option('exact-match'),
+            'allow-unsafe' => $this->option('allow-unsafe'),
+            'skip-verify' => $this->option('skip-verify'),
+            'partitioning' => $this->option('partitioning'),
+            'strip-definer' => $this->option('strip-definer'),
+            'allow-auto-inc' => $this->option('allow-auto-inc'),
+            'allow-charset' => $this->option('allow-charset'),
+            'allow-compression' => $this->option('allow-compression'),
+            'allow-definer' => $this->option('allow-definer'),
+            'allow-engine' => $this->option('allow-engine'),
+            'safe-below-size' => $this->option('safe-below-size'),
+        ])
+        ->filter()
+        ->merge($this->getLintArgs())
+        ->toArray();
 
         if ($this->getConfig('skeema.alter_wrapper.enabled', false)) {
-            $args['alter-wrapper'] = $this->getAlterWrapperCommand();
-            $args['alter-wrapper-min-size'] = $this->getConfig(('skeema.alter_wrapper.min_size'), '0');
+            return collect($args)
+                ->merge([
+                    'alter-wrapper' => $this->getAlterWrapperCommand(),
+                    'alter-wrapper-min-size' => $this->getConfig('skeema.alter_wrapper.min_size', '0'),
+                ])
+                ->toArray();
         }
 
+        return $args;
+    }
+
+    /**
+     * Get the arguments to run Skeema's lint command, based on the configuration.
+     *
+     * If the 'skeema.lint.diff' or 'skeema.lint.rules' configuration values are not set or invalid,
+     * return an array indicating that linting should be skipped.
+     *
+     * The method merges the base and diff rules, creates an array of options from them.
+     *
+     * @return array The associative array of options to run Skeema's lint command with.
+     */
+    private function getLintArgs(): array
+    {
         $baseRules = $this->getConfig('skeema.lint.rules', []);
         $diffRules = $this->getConfig('skeema.lint.diff', []);
 
         if ($diffRules === false || ! is_array($diffRules) || ! is_array($baseRules)) {
-            $args['skip-lint'] = true;
-
-            return $args;
+            return ['skip-lint' => true];
         }
 
-        collect(array_merge($baseRules, $diffRules))->each(function ($value, $key) use (&$args) {
-            $option = $this->laravel->make($key)->getOptionString();
-
-            if ($option) {
-                $args[$option] = $value;
-            }
-        });
-
-        return $args;
+        return collect($baseRules)->merge($diffRules)
+            ->mapWithKeys(function ($value, $key) {
+                return [$this->laravel->make($key)->getOptionString() => $value];
+            })
+            ->toArray();
     }
 }

--- a/src/Commands/SkeemaLintCommand.php
+++ b/src/Commands/SkeemaLintCommand.php
@@ -134,7 +134,6 @@ class SkeemaLintCommand extends SkeemaBaseCommand
         parent::onOutput($type, $buffer);
     }
 
-
     /**
      * Reference: https://www.skeema.io/docs/commands/lint/
      */

--- a/src/Commands/SkeemaLintCommand.php
+++ b/src/Commands/SkeemaLintCommand.php
@@ -64,8 +64,6 @@ class SkeemaLintCommand extends SkeemaBaseCommand
             'temp-schema-threads' => ($this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads'))) ? $this->option('temp-schema-threads') : null,
             'temp-schema-binlog' => $this->option('temp-schema-binlog'),
             'skip-format' => $this->option('skip-format') ? true : null,
-            'include-auto-inc' => $this->option('include-auto-inc') ? true : null,
-            'new-schemas' => $this->option('new-schemas') ? true : null,
             'strip-definer' => $this->option('strip-definer'),
             'strip-partitioning' => $this->option('strip-partitioning') ? true : null,
             'update-views' => $this->option('update-views') ? true : null,

--- a/src/Commands/SkeemaMigrateAndPullCommand.php
+++ b/src/Commands/SkeemaMigrateAndPullCommand.php
@@ -49,7 +49,7 @@ class SkeemaMigrateAndPullCommand extends Command
         $files = collect($this->migrator->getMigrationFiles($this->getMigrationPath()));
 
         if ($files->isNotEmpty()) {
-            if (blank($this->option('no-push'))) {
+            if (! $this->option('no-push')) {
                 $status = $this->call('skeema:push', [
                     '--force' => true,
                     '--allow-unsafe' => true,
@@ -68,7 +68,7 @@ class SkeemaMigrateAndPullCommand extends Command
 
             $files->each(function ($file, $key) use ($ran) {
                 if (
-                    blank($this->option('keep-migrations'))
+                    ! $this->option('keep-migrations')
                     && $ran->contains($key)
                 ) {
                     $this->warn("Deleting ran migration: {$key} {$file}");
@@ -83,7 +83,7 @@ class SkeemaMigrateAndPullCommand extends Command
 
                 $this->info("Ran migration: {$key} {$file}");
 
-                if (blank($this->option('keep-migrations'))) {
+                if (! $this->option('keep-migrations')) {
                     $this->warn("Deleting ran migration: {$key} {$file}");
                     $this->filesystem->delete($file);
                 }

--- a/src/Commands/SkeemaPullCommand.php
+++ b/src/Commands/SkeemaPullCommand.php
@@ -54,50 +54,19 @@ class SkeemaPullCommand extends SkeemaBaseCommand
      */
     private function makeArgs(): array
     {
-        $args = [];
-
-        if ($this->option('temp-schema')) {
-            $args['temp-schema'] = $this->option('temp-schema');
-        } else {
-            $args['temp-schema'] = $this->getTempSchemaName();
-        }
-
-        if ($this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads'))) {
-            $args['temp-schema-threads'] = $this->option('temp-schema-threads');
-        }
-
-        if ($this->option('temp-schema-binlog')) {
-            $args['temp-schema-binlog'] = $this->option('temp-schema-binlog');
-        }
-
-        if ($this->option('skip-format')) {
-            $args['skip-format'] = true;
-        }
-
-        if ($this->option('include-auto-inc')) {
-            $args['include-auto-inc'] = true;
-        }
-
-        if ($this->option('new-schemas')) {
-            $args['new-schemas'] = true;
-        }
-
-        if ($this->option('strip-definer')) {
-            $args['strip-definer'] = $this->option('strip-definer');
-        }
-
-        if ($this->option('strip-partitioning')) {
-            $args['strip-partitioning'] = true;
-        }
-
-        if ($this->option('update-views')) {
-            $args['update-views'] = true;
-        }
-
-        if ($this->option('update-partitioning')) {
-            $args['update-partitioning'] = true;
-        }
-
-        return $args;
+        return collect([
+            'temp-schema' => $this->option('temp-schema') ?: $this->getTempSchemaName(),
+            'temp-schema-threads' => ($this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads'))) ? $this->option('temp-schema-threads') : null,
+            'temp-schema-binlog' => $this->option('temp-schema-binlog'),
+            'skip-format' => $this->option('skip-format') ? true : null,
+            'include-auto-inc' => $this->option('include-auto-inc') ? true : null,
+            'new-schemas' => $this->option('new-schemas') ? true : null,
+            'strip-definer' => $this->option('strip-definer'),
+            'strip-partitioning' => $this->option('strip-partitioning') ? true : null,
+            'update-views' => $this->option('update-views') ? true : null,
+            'update-partitioning' => $this->option('update-partitioning') ? true : null,
+        ])
+        ->filter()
+        ->toArray();
     }
 }

--- a/src/Commands/SkeemaPushCommand.php
+++ b/src/Commands/SkeemaPushCommand.php
@@ -115,7 +115,7 @@ class SkeemaPushCommand extends SkeemaBaseCommand
      *
      * The method merges the base and diff rules, creates an array of options from them.
      *
-     * @return array The associative array of options to run Skeema's lint command with.
+     * @return array<string, mixed> The associative array of options to run Skeema's lint command with.
      */
     private function getLintArgs(): array
     {

--- a/src/Commands/SkeemaPushCommand.php
+++ b/src/Commands/SkeemaPushCommand.php
@@ -146,7 +146,7 @@ class SkeemaPushCommand extends SkeemaBaseCommand
             throw new \Smakecloud\Skeema\Exceptions\SkeemaPushFatalErrorException();
         }
 
-        if (!$this->option('dry-run')) {
+        if (! $this->option('dry-run')) {
             // @codeCoverageIgnoreStart
             throw new \Smakecloud\Skeema\Exceptions\SkeemaPushCouldNotUpdateTableException();
             // @codeCoverageIgnoreEnd

--- a/src/Commands/SkeemaPushCommand.php
+++ b/src/Commands/SkeemaPushCommand.php
@@ -68,113 +68,69 @@ class SkeemaPushCommand extends SkeemaBaseCommand
      */
     private function makeArgs(): array
     {
-        $args = [];
-
-        if ($this->option('temp-schema')) {
-            $args['temp-schema'] = $this->option('temp-schema');
-        } else {
-            $args['temp-schema'] = $this->getTempSchemaName();
-        }
-
-        if ($this->option('temp-schema-threads') && is_numeric($this->option('temp-schema-threads'))) {
-            $args['temp-schema-threads'] = $this->option('temp-schema-threads');
-        }
-
-        if ($this->option('temp-schema-binlog')) {
-            $args['temp-schema-binlog'] = $this->option('temp-schema-binlog');
-        }
-
-        if ($this->option('alter-algorithm')) {
-            $args['alter-algorithm'] = $this->option('alter-algorithm');
-        }
-
-        if ($this->option('alter-lock')) {
-            $args['alter-lock'] = $this->option('alter-lock');
-        }
-
-        if ($this->option('alter-validate-virtual')) {
-            $args['alter-validate-virtual'] = $this->option('alter-validate-virtual');
-        }
-
-        if ($this->option('compare-metadata')) {
-            $args['compare-metadata'] = $this->option('compare-metadata');
-        }
-
-        if ($this->option('exact-match')) {
-            $args['exact-match'] = $this->option('exact-match');
-        }
-
-        if ($this->option('partitioning')) {
-            $args['partitioning'] = $this->option('partitioning');
-        }
-
-        if ($this->option('strip-definer')) {
-            $args['strip-definer'] = $this->option('strip-definer');
-        }
-
-        if ($this->option('allow-unsafe')) {
-            $args['allow-unsafe'] = true;
-        }
-
-        if ($this->option('skip-verify')) {
-            $args['skip-verify'] = true;
-        }
-
-        if ($this->option('dry-run')) {
-            $args['dry-run'] = true;
-        }
-
-        if ($this->option('foreign-key-checks')) {
-            $args['foreign-key-checks'] = true;
-        }
-
-        if ($this->option('allow-auto-inc')) {
-            $args['allow-auto-inc'] = $this->option('allow-auto-inc');
-        }
-
-        if ($this->option('allow-charset')) {
-            $args['allow-charset'] = $this->option('allow-charset');
-        }
-
-        if ($this->option('allow-compression')) {
-            $args['allow-compression'] = $this->option('allow-compression');
-        }
-
-        if ($this->option('allow-definer')) {
-            $args['allow-definer'] = $this->option('allow-definer');
-        }
-
-        if ($this->option('allow-engine')) {
-            $args['allow-engine'] = $this->option('allow-engine');
-        }
-
-        if ($this->option('safe-below-size')) {
-            $args['safe-below-size'] = $this->option('safe-below-size');
-        }
+        $args = collect([
+            'temp-schema' => $this->option('temp-schema') ?: $this->getTempSchemaName(),
+            'temp-schema-threads' => is_numeric($this->option('temp-schema-threads')) ? $this->option('temp-schema-threads') : null,
+            'temp-schema-binlog' => $this->option('temp-schema-binlog'),
+            'alter-algorithm' => $this->option('alter-algorithm'),
+            'alter-lock' => $this->option('alter-lock'),
+            'alter-validate-virtual' => $this->option('alter-validate-virtual'),
+            'compare-metadata' => $this->option('compare-metadata'),
+            'exact-match' => $this->option('exact-match'),
+            'partitioning' => $this->option('partitioning'),
+            'strip-definer' => $this->option('strip-definer'),
+            'allow-unsafe' => $this->option('allow-unsafe') ? true : null,
+            'skip-verify' => $this->option('skip-verify') ? true : null,
+            'dry-run' => $this->option('dry-run') ? true : null,
+            'foreign-key-checks' => $this->option('foreign-key-checks') ? true : null,
+            'allow-auto-inc' => $this->option('allow-auto-inc'),
+            'allow-charset' => $this->option('allow-charset'),
+            'allow-compression' => $this->option('allow-compression'),
+            'allow-definer' => $this->option('allow-definer'),
+            'allow-engine' => $this->option('allow-engine'),
+            'safe-below-size' => $this->option('safe-below-size'),
+        ])
+        ->filter()
+        ->merge($this->getLintArgs())
+        ->filter()
+        ->toArray();
 
         if ($this->getConfig('skeema.alter_wrapper.enabled', false)) {
-            $args['alter-wrapper'] = $this->getAlterWrapperCommand();
-            $args['alter-wrapper-min-size'] = $this->getConfig(('skeema.alter_wrapper.min_size'), '0');
+            return collect($args)
+                ->merge([
+                    'alter-wrapper' => $this->getAlterWrapperCommand(),
+                    'alter-wrapper-min-size' => $this->getConfig('skeema.alter_wrapper.min_size', '0'),
+                ])
+                ->toArray();
         }
-
-        $baseRules = $this->getConfig('skeema.lint.rules', []);
-        $pushRules = $this->getConfig('skeema.lint.push', []);
-
-        if ($this->option('skip-lint') || $pushRules === false || ! is_array($pushRules) || ! is_array($baseRules)) {
-            $args['skip-lint'] = true;
-
-            return $args;
-        }
-
-        collect(array_merge($baseRules, $pushRules))->each(function ($value, $key) use (&$args) {
-            $option = $this->laravel->make($key)->getOptionString();
-
-            if ($option) {
-                $args[$option] = $value;
-            }
-        });
 
         return $args;
+    }
+
+    /**
+     * Get the arguments to run Skeema's lint command, based on the configuration.
+     *
+     * If the 'skeema.lint.diff' or 'skeema.lint.rules' configuration values are not set or invalid,
+     * return an array indicating that linting should be skipped.
+     *
+     * The method merges the base and diff rules, creates an array of options from them.
+     *
+     * @return array The associative array of options to run Skeema's lint command with.
+     */
+    private function getLintArgs(): array
+    {
+        $baseRules = $this->getConfig('skeema.lint.rules', []);
+        $diffRules = $this->getConfig('skeema.lint.diff', []);
+
+        if ($this->option('skip-lint') || $diffRules === false || ! is_array($diffRules) || ! is_array($baseRules)) {
+            return ['skip-lint' => true];
+        }
+
+        return collect($baseRules)->merge($diffRules)
+            ->mapWithKeys(function ($value, $key) {
+                return [$this->laravel->make($key)->getOptionString() => $value];
+            })
+            ->toArray();
     }
 
     /**
@@ -182,9 +138,15 @@ class SkeemaPushCommand extends SkeemaBaseCommand
      */
     protected function onError(Process $process): void
     {
+        if ($process->getExitCode() < 1) {
+            return;
+        }
+
         if ($process->getExitCode() >= 2) {
             throw new \Smakecloud\Skeema\Exceptions\SkeemaPushFatalErrorException();
-        } elseif ($process->getExitCode() === 1 && !$this->option('dry-run')) {
+        }
+
+        if (!$this->option('dry-run')) {
             // @codeCoverageIgnoreStart
             throw new \Smakecloud\Skeema\Exceptions\SkeemaPushCouldNotUpdateTableException();
             // @codeCoverageIgnoreEnd

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -48,5 +48,4 @@ class ServiceProvider extends IlluminateServiceProvider
 
         $this->commands($commands->keys()->toArray());
     }
-
 }

--- a/tests/Commands/SkeemaInitCommandTest.php
+++ b/tests/Commands/SkeemaInitCommandTest.php
@@ -23,6 +23,7 @@ class SkeemaInitCommandTest extends TestCase
         $this->assertTrue($this->app->isProduction());
 
         $this->artisan('skeema:init')
+            ->expectsOutput('Attention - Your consent has significant implications.')
             ->expectsConfirmation('Running skeema init will overwrite any existing schema files. Proceed?', 'no')
             ->expectsOutput('Command cancelled.')
             ->assertExitCode(
@@ -30,6 +31,7 @@ class SkeemaInitCommandTest extends TestCase
             );
 
         $this->artisan('skeema:init')
+            ->expectsOutput('Attention - Your consent has significant implications.')
             ->expectsConfirmation('Running skeema init will overwrite any existing schema files. Proceed?', 'yes')
             ->assertExitCode(0);
     }

--- a/tests/Commands/SkeemaPushCommandTest.php
+++ b/tests/Commands/SkeemaPushCommandTest.php
@@ -37,6 +37,7 @@ class SkeemaPushCommandTest extends TestCase
         $this->artisan('skeema:init --force')->assertSuccessful();
 
         $this->artisan('skeema:push')
+            ->expectsOutput('Attention - Your consent has significant implications.')
             ->expectsConfirmation('Running skeema push in production. Proceed?', 'no')
             ->expectsOutput('Command cancelled.')
             ->assertExitCode(1);

--- a/tests/Commands/SkeemaPushCommandTest.php
+++ b/tests/Commands/SkeemaPushCommandTest.php
@@ -72,5 +72,4 @@ class SkeemaPushCommandTest extends TestCase
                 (new \Smakecloud\Skeema\Exceptions\SkeemaPushFatalErrorException())->getExitCode()
             );
     }
-
 }


### PR DESCRIPTION
## Description

Refactored several Artisan commands to follow Laravel best practices, using the Collection class and helper functions, and avoiding native PHP functions whenever possible.

The affected commands now have improved readability, maintainability, and testability, with a more consistent and idiomatic Laravel code style. 